### PR TITLE
Change FetchDataWorker update intent to point a receiver.

### DIFF
--- a/app/src/main/java/com/gmail/remarkable/development/airrybnik/data/workers/FetchDataWorker.kt
+++ b/app/src/main/java/com/gmail/remarkable/development/airrybnik/data/workers/FetchDataWorker.kt
@@ -51,7 +51,8 @@ class FetchDataWorker @WorkerInject constructor(
         val widgetIds =
             appWidgetManager.getAppWidgetIds(ComponentName(appContext, Pm10AppWidget::class.java))
 
-        val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE).apply {
+        val intent = Intent(appContext, Pm10AppWidget::class.java).apply {
+            action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
             putExtra(Pm10AppWidget.INTENT_SENSOR_DATE, date)
             putExtra(Pm10AppWidget.INTENT_SENSOR_VALUE, value)
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)


### PR DESCRIPTION
Fix #15 
Now intent constructor contains context and Pm10AppWidge class refference to point the appropriate AppWidgetProvider.